### PR TITLE
Nullables Fix

### DIFF
--- a/ModThatIsNotMod/ModThatIsNotMod/ModThatIsNotMod.csproj
+++ b/ModThatIsNotMod/ModThatIsNotMod/ModThatIsNotMod.csproj
@@ -159,6 +159,7 @@
     <Compile Include="MonoBehaviours\SimpleGunModifiers.cs" />
     <Compile Include="MonoBehaviours\InstantiateOnFire.cs" />
     <Compile Include="Notifications.cs" />
+    <Compile Include="Nullables\BoxedNullable.cs" />
     <Compile Include="Player.cs" />
     <Compile Include="Internals\Preferences.cs" />
     <Compile Include="Pooling\SimplePool.cs" />

--- a/ModThatIsNotMod/ModThatIsNotMod/ModThatIsNotMod.csproj
+++ b/ModThatIsNotMod/ModThatIsNotMod/ModThatIsNotMod.csproj
@@ -160,6 +160,7 @@
     <Compile Include="MonoBehaviours\InstantiateOnFire.cs" />
     <Compile Include="Notifications.cs" />
     <Compile Include="Nullables\BoxedNullable.cs" />
+    <Compile Include="Nullables\NullableMethodExtensions.cs" />
     <Compile Include="Player.cs" />
     <Compile Include="Internals\Preferences.cs" />
     <Compile Include="Pooling\SimplePool.cs" />

--- a/ModThatIsNotMod/ModThatIsNotMod/ModThatIsNotMod.csproj
+++ b/ModThatIsNotMod/ModThatIsNotMod/ModThatIsNotMod.csproj
@@ -24,6 +24,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>bin\Debug\ModThatIsNotMod.xml</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,6 +35,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <DocumentationFile>bin\Release\ModThatIsNotMod.xml</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">

--- a/ModThatIsNotMod/ModThatIsNotMod/Nullables/BoxedNullable.cs
+++ b/ModThatIsNotMod/ModThatIsNotMod/Nullables/BoxedNullable.cs
@@ -1,0 +1,120 @@
+﻿namespace ModThatIsNotMod.Nullables
+{
+    using HarmonyLib;
+    using System;
+    using System.Runtime.InteropServices;
+    using UnhollowerBaseLib;
+
+    public class BoxedNullable<T> : Il2CppSystem.ValueType where T : unmanaged
+    {
+        private static readonly IntPtr classPtr;
+        private static readonly IntPtr TClassPtr;
+        private static readonly int valueSize;
+        private static readonly int marshalSize;
+        private static readonly int hasValueOffset;
+
+        static BoxedNullable()
+        {
+            classPtr = Il2CppClassPointerStore<Il2CppSystem.Nullable<T>>.NativeClassPtr;
+            TClassPtr = Il2CppClassPointerStore<T>.NativeClassPtr;
+
+            uint align = 0;
+            hasValueOffset = (int)IL2CPP.il2cpp_field_get_offset(IL2CPP.GetIl2CppField(classPtr, "has_value"));
+            valueSize = IL2CPP.il2cpp_class_value_size(TClassPtr, ref align);
+            marshalSize = Marshal.SizeOf(typeof(T));
+        }
+
+        public IntPtr ValuePtr => IL2CPP.il2cpp_object_unbox(Pointer);
+
+        public unsafe bool HasValue
+        {
+            get => (*(byte*)(ValuePtr + hasValueOffset)) != 0;
+            set => (*(byte*)(ValuePtr + hasValueOffset)) = (value ? (byte)1 : (byte)0);
+        }
+
+        public unsafe T Value
+        {
+            get
+            {
+                if (marshalSize == valueSize)
+                {
+                    return *(T*)ValuePtr;
+                }
+                else if (valueSize == 1 && marshalSize > 0)// ie, bool
+                {
+                    T x = default;
+                    *((byte*)&x) = *(byte*)ValuePtr;
+                    return x;
+                }
+
+                throw new InvalidOperationException("Interop done goof?");
+            }
+            set
+            {
+                if (marshalSize == valueSize)
+                {
+                    *(T*)ValuePtr = value;
+                }
+                else if (valueSize == 1 && marshalSize > 0)
+                {
+                    *(byte*)ValuePtr = *((byte*)&value);
+                }
+
+                throw new InvalidOperationException("Interop done goof?");
+            }
+        }
+
+        public unsafe BoxedNullable(T? nullable)
+        {
+            IntPtr obj = IL2CPP.il2cpp_object_new(classPtr);
+
+            uint gcHandle = RuntimeSpecificsStore.ShouldUseWeakRefs(classPtr)
+                ? IL2CPP.il2cpp_gchandle_new_weakref(obj, false)
+                : IL2CPP.il2cpp_gchandle_new(obj, false);
+            AccessTools.Field(typeof(Il2CppObjectBase), "myGcHandle").SetValue(this, gcHandle);
+
+            if (nullable.HasValue)
+            {
+                this.Value = nullable.Value;
+                this.HasValue = true;
+            }
+            else
+            {
+                this.Value = default;
+                this.HasValue = false;
+            }
+        }
+
+        public unsafe BoxedNullable(T value)
+        {
+            IntPtr obj = IL2CPP.il2cpp_object_new(classPtr);
+            IntPtr dataPtr = IL2CPP.il2cpp_object_unbox(obj);
+            if (value is bool b)
+            {
+                Set(dataPtr, b ? (byte)1 : (byte)0);
+            }
+            else
+            {
+                Set(dataPtr, value);
+            }
+
+            *(byte*)(dataPtr + hasValueOffset) = 1;
+
+            uint gcHandle = RuntimeSpecificsStore.ShouldUseWeakRefs(classPtr)
+                ? IL2CPP.il2cpp_gchandle_new_weakref(obj, false)
+                : IL2CPP.il2cpp_gchandle_new(obj, false);
+
+            AccessTools.Field(typeof(Il2CppObjectBase), "myGcHandle").SetValue(this, gcHandle);
+        }
+
+        private static unsafe void Set<U>(IntPtr tgt, U value) where U : unmanaged
+        {
+            *(U*)tgt = value;
+        }
+
+        public static implicit operator Il2CppSystem.Nullable<T>(BoxedNullable<T> me)
+        {
+            return new Il2CppSystem.Nullable<T>(me.Pointer);
+        }
+    }
+}

--- a/ModThatIsNotMod/ModThatIsNotMod/Nullables/BoxedNullable.cs
+++ b/ModThatIsNotMod/ModThatIsNotMod/Nullables/BoxedNullable.cs
@@ -28,8 +28,8 @@
 
         public unsafe bool HasValue
         {
-            get => (*(byte*)(ValuePtr + hasValueOffset)) != 0;
-            set => (*(byte*)(ValuePtr + hasValueOffset)) = (value ? (byte)1 : (byte)0);
+            get => (*(byte*)(Pointer + hasValueOffset)) != 0;
+            set => (*(byte*)(Pointer + hasValueOffset)) = (value ? (byte)1 : (byte)0);
         }
 
         public unsafe T Value
@@ -59,8 +59,10 @@
                 {
                     *(byte*)ValuePtr = *((byte*)&value);
                 }
-
-                throw new InvalidOperationException("Interop done goof?");
+                else
+                {
+                    throw new InvalidOperationException("Interop done goof?");
+                }
             }
         }
 

--- a/ModThatIsNotMod/ModThatIsNotMod/Nullables/NullableMethodExtensions.cs
+++ b/ModThatIsNotMod/ModThatIsNotMod/Nullables/NullableMethodExtensions.cs
@@ -1,0 +1,122 @@
+﻿using StressLevelZero.AI;
+using StressLevelZero.Pool;
+using StressLevelZero.VFX;
+using StressLevelZero.Zones;
+using UnhollowerBaseLib;
+using UnityEngine;
+using UnityEngine.Audio;
+
+namespace ModThatIsNotMod.Nullables
+{
+    public static class NullableMethodExtensions
+    {
+        public static void Attenuate(this AudioPlayer inst, float? volume, float? pitch, float? minDistance)
+        {
+            inst.Attenuate(
+                new BoxedNullable<float>(volume),
+                new BoxedNullable<float>(pitch),
+                new BoxedNullable<float>(minDistance));
+        }
+
+        public static void Play(this AudioPlayer inst, AudioClip clip, AudioMixerGroup mixerGroup, float? volume, bool? isLooping, float? pitch, float? minDistance)
+        {
+            inst.Play(clip, mixerGroup,
+                new BoxedNullable<float>(volume),
+                new BoxedNullable<bool>(isLooping),
+                new BoxedNullable<float>(pitch),
+                new BoxedNullable<float>(minDistance));
+        }
+
+        public static void Play(this AudioPlayer inst, AudioClip[] clips, AudioMixerGroup mixerGroup, float? volume, bool? isLooping, float? pitch, float? minDistance)
+        {
+            Il2CppReferenceArray<AudioClip> clipsArr = new Il2CppReferenceArray<AudioClip>(clips);
+            inst.Play(clipsArr, mixerGroup,
+                new BoxedNullable<float>(volume),
+                new BoxedNullable<bool>(isLooping),
+                new BoxedNullable<float>(pitch),
+                new BoxedNullable<float>(minDistance));
+        }
+
+        public static void AudioPlayer_PlayAtPoint(AudioClip clip, Vector3 position, AudioMixerGroup mixerGroup, float? volume, bool? isLooping, float? pitch, float? minDistance)
+        {
+            AudioPlayer.PlayAtPoint(clip, position, mixerGroup,
+                new BoxedNullable<float>(volume),
+                new BoxedNullable<bool>(isLooping),
+                new BoxedNullable<float>(pitch),
+                new BoxedNullable<float>(minDistance));
+        }
+
+        public static void AudioPlayer_PlayAtPoint(AudioClip[] clips, Vector3 position, AudioMixerGroup mixerGroup, float? volume, bool? isLooping, float? pitch, float? minDistance)
+        {
+            Il2CppReferenceArray<AudioClip> clipsArr = new Il2CppReferenceArray<AudioClip>(clips);
+            AudioPlayer.PlayAtPoint(clipsArr, position, mixerGroup,
+                new BoxedNullable<float>(volume),
+                new BoxedNullable<bool>(isLooping),
+                new BoxedNullable<float>(pitch),
+                new BoxedNullable<float>(minDistance));
+        }
+
+        public static void SetTrigger(this AITrigger inst, float? radius, float? fov, TriggerManager.TriggerTypes? type)
+        {
+            inst.SetTrigger(
+                new BoxedNullable<float>(radius),
+                new BoxedNullable<float>(fov),
+                new BoxedNullable<TriggerManager.TriggerTypes>(type));
+        }
+
+        public static GameObject Spawn(this Pool inst, Vector3 position, Quaternion rotation, Vector3? scale, bool? autoEnable)
+        {
+            return inst.Spawn(position, rotation,
+                new BoxedNullable<Vector3>(scale),
+                new BoxedNullable<bool>(autoEnable));
+        }
+
+        public static void Despawn(this Poolee inst, bool? playVFX, Color? despawnColor)
+        {
+            inst.Despawn(
+                new BoxedNullable<bool>(playVFX),
+                new BoxedNullable<Color>(despawnColor));
+        }
+
+        public static void OnSpawn(this Poolee poolee, Vector3? scale)
+        {
+            poolee.OnSpawn(
+                new BoxedNullable<Vector3>(scale));
+        }
+
+        public static GameObject PoolManager_Spawn(string name, Vector3 position, Quaternion rotation, bool? autoEnable)
+        {
+            return PoolManager.Spawn(name, position, rotation, new BoxedNullable<bool>(autoEnable));
+        }
+
+        public static GameObject PoolManager_Spawn(string name, Vector3 position, Quaternion rotation, Vector3 scale, bool? autoEnable)
+        {
+            return PoolManager.Spawn(name, position, rotation, scale, new BoxedNullable<bool>(autoEnable));
+        }
+
+        public static void SetRigidbody(this SpawnFragment inst, int idx, Vector3? velocity, Vector3? angularVelocity, float? mass, Vector3? worldCenter, float? explosiveForce)
+        {
+            inst.SetRigidbody(idx,
+                new BoxedNullable<Vector3>(velocity),
+                new BoxedNullable<Vector3>(angularVelocity),
+                new BoxedNullable<float>(mass),
+                new BoxedNullable<Vector3>(worldCenter),
+                new BoxedNullable<float>(explosiveForce));
+        }
+
+        public static void SpawnEffect(this DespawnMeshVFX inst, Color? color)
+        {
+            inst.SpawnEffect(new BoxedNullable<Color>(color));
+        }
+
+        public static void SpawnEffectDisabledObj(this DespawnMeshVFX inst, Color? color)
+        {
+            inst.SpawnEffectDisabledObj(new BoxedNullable<Color>(color));
+        }
+
+        public static void Despawn(this ZoneTracker inst, bool? playVFX)
+        {
+            inst.Despawn(new BoxedNullable<bool>(playVFX));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Feel free to make a PR for new features and bug fixes, just make sure the code i
 - Spawn items from pools
 - Check if mods are up to date
 - Send notifications to the player
+- Access methods with Nullable<T> arguments that are normally broken
 - Much more
 
 ### Custom Items
@@ -72,6 +73,8 @@ Chromium - Helped me create Boneworks Modding Toolkit and Custom Items Framework
 L4rs - Added a color element to BoneMenu and made a way for a menu to be attached to an item
 
 Trev - Modified the CustomMonobehaviourHandler to support custom json serializers
+  
+WNP78 - Added `BoxedNullable` and `NullableMethodExtensions`
 
 And thanks to anyone who tested, told me about bugs, or suggested new features for the mod!
 


### PR DESCRIPTION
Hi mr chap chap

Here have code that fixes the nullables
Just put `using ModThatIsNotMod.Nullables;` at the top of your script and you will get extension methods for things that use nullables, allowing you to call them without issue, simply passing in a C# nullable.

There is also the static: `NullableMethodExtensions.AudioPlayer_PlayAtPoint` which has 2 overloads.

If you want to create your own nullables for other purposes, just use `BoxedNullable<T>`. This can implicitly convert to an Il2CppSystem.Nullable<T> for use in methods.

-wnp